### PR TITLE
Simplified block definition to protect all routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .direnv/
 .envrc
 .ruby-version
+*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # rspec failure tracking
 .rspec_status
+
+.direnv/
+.envrc
+.ruby-version

--- a/lib/rack/bearer_auth/middleware.rb
+++ b/lib/rack/bearer_auth/middleware.rb
@@ -8,7 +8,7 @@ module Rack
     class Middleware
       def initialize(app, &block)
         raise ArgumentError, "Block argument is required." unless block_given?
-        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless valid_block_arity?(&block)
+        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless block.arity <= 1
 
         @app = app
         @match_patterns = []
@@ -61,10 +61,6 @@ module Rack
           end
         end
         nil
-      end
-
-      def valid_block_arity?(&block)
-        block.arity <= 1
       end
     end
   end

--- a/lib/rack/bearer_auth/middleware.rb
+++ b/lib/rack/bearer_auth/middleware.rb
@@ -8,7 +8,7 @@ module Rack
     class Middleware
       def initialize(app, &block)
         raise ArgumentError, "Block argument is required." unless block_given?
-        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless block.arity <= 1
+        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless (block.arity <= 1)
 
         @app = app
         @match_patterns = []

--- a/lib/rack/bearer_auth/middleware.rb
+++ b/lib/rack/bearer_auth/middleware.rb
@@ -8,7 +8,7 @@ module Rack
     class Middleware
       def initialize(app, &block)
         raise ArgumentError, "Block argument is required." unless block_given?
-        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless (block.arity <= 1)
+        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless valid_block_arity?(&block)
 
         @app = app
         @match_patterns = []
@@ -61,6 +61,10 @@ module Rack
           end
         end
         nil
+      end
+
+      def valid_block_arity?(&block)
+        block.arity <= 1
       end
     end
   end

--- a/lib/rack/bearer_auth/middleware.rb
+++ b/lib/rack/bearer_auth/middleware.rb
@@ -8,7 +8,7 @@ module Rack
     class Middleware
       def initialize(app, &block)
         raise ArgumentError, "Block argument is required." unless block_given?
-        raise ArgumentError, "Block argument can only accept 0 or 1 arguments." unless block.arity <= 1
+        raise ArgumentError, "Block can only accept 0 or 1 arguments." unless block.arity <= 1
 
         @app = app
         @match_patterns = []

--- a/lib/rack/bearer_auth/middleware.rb
+++ b/lib/rack/bearer_auth/middleware.rb
@@ -8,11 +8,16 @@ module Rack
     class Middleware
       def initialize(app, &block)
         raise ArgumentError, "Block argument is required." unless block_given?
+        raise ArgumentError, "Block argument can only accept 0 or 1 arguments." unless block.arity <= 1
 
         @app = app
         @match_patterns = []
 
-        instance_exec(&block)
+        # original block handler
+        instance_exec(&block) if block.arity == 0
+
+        # token based block handler
+        match(&block) if block.arity == 1
       end
 
       def call(env)

--- a/spec/rack/bearer_auth/middleware_spec.rb
+++ b/spec/rack/bearer_auth/middleware_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Rack::BearerAuth::Middleware do
 
       it { expect { subject }.to raise_error(ArgumentError) }
     end
+
+    context "with block argument and single arity" do
+      subject do
+        described_class.new(test_app) do |token|
+          token == 'test_token'
+        end
+      end
+
+      it { expect { subject }.not_to raise_error }
+    end
   end
 
   describe "GET /foo" do


### PR DESCRIPTION
Hello and thank you for creating this gem :-)

I have submitted this pull-request to add an additional method of configuration to further simplify it's usage when protecting all routes to sub-apps aka downstream middlewares.

The additional configuration method submitted in this pull-request should be backwards with the current methods of configuration, at least based on the test specs provided and my own personal use and testing. 

Below, I have provided examples of the current methods of configuration along with the new additional method of configuration submitted as part of this pull-request.   

```ruby
# rack configuration method in current implementation
use Rack::BearerAuth::Middleware do
  match path: '/', token: 'test_token'
  match path: '/hello', token: 'test_token'
end

# alternate rack configuration method in current implementation 
use Rack::BearerAuth::Middleware do
  match { |token| token = 'test_token' }
end

# additional rack configuration method submitted as part of this pull-request
use Rack::BearerAuth::Middleware do |token|
  token == 'test_token'
end
```

If you have any questions, comments, suggestions, recommendations, and/or requirements in order to move this pull-request forward please feel free to reach out to me.     

Thank you for taking the time to review my pull-request. 
-pj
